### PR TITLE
Fixed dead links on 'contributing' page

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -20,9 +20,9 @@ New PowerUps are welcomed in any programming language or framework. (Node.js/Bot
 - [X] A precomposed Dockerfile (a Deploy to Heroku button is recommended but not mandatory)
 
 #### Directions to Submit a new Starter Kit
-The Cisco Webex Teams Ambassador PowerUps website is powered by GitHub pages. In order to add a new listing submit a Pull Request to the PowerUps [repository](https://github.com/WebexTeamsAmbassadors/StarterKits/).
+The Cisco Webex Teams Ambassador PowerUps website is powered by GitHub pages. In order to add a new listing submit a Pull Request to the PowerUps [repository](https://github.com/CiscoWebexTeamsAmbassadors/StarterKits/).
 
-This Pull Request needs to consist of a new markdown file that carries the name of your project submission as an addition to the /bots folder,  my-application.md as an example. The file should be in the following format ([example](https://github.com/WebexTeamsAmbassadors/StarterKits/commit/d13ef671130f7f112b28b1e39730713250179838)):
+This Pull Request needs to consist of a new markdown file that carries the name of your project submission as an addition to the /bots folder,  my-application.md as an example. The file should be in the following format ([example](https://github.com/CiscoWebexTeamsAmbassadors/StarterKits/commit/d13ef671130f7f112b28b1e39730713250179838)):
 
 ``` markdown
 ---


### PR DESCRIPTION
Fixed dead links on 'contributing' page leading to old GitHub organization that does not exist.